### PR TITLE
Please review expect(q.to_s).must_equal(value)

### DIFF
--- a/test/queue_test.rb
+++ b/test/queue_test.rb
@@ -111,6 +111,6 @@ describe "Test Queue Implementation" do
     q.enqueue(210)
     q.dequeue
 
-    expect(q.to_s).must_equal('[30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200]')
+     expect(q.to_s).must_equal('[40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 150, 160, 170, 180, 190, 200, 210]')
   end
 end


### PR DESCRIPTION
I'm proposing adding a second 150 value back into the expect statement as well as removing the 30 value from the beginning of the array (since the last dequeue method call will remove this value). This proposal should match the enqueue and dequeue method calls; but please review! Thank you!

